### PR TITLE
Metrics project

### DIFF
--- a/.azure-pipelines/patch_readline.sh
+++ b/.azure-pipelines/patch_readline.sh
@@ -1,3 +1,3 @@
 ruby_version=$(ruby -e 'puts RUBY_VERSION')
 
-git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby --unsafe-paths
+git apply --ignore-space-change --ignore-whitespace '.azure-pipelines\rbreadline.diff' --directory="C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby" --unsafe-paths

--- a/.azure-pipelines/patch_readline.sh
+++ b/.azure-pipelines/patch_readline.sh
@@ -1,0 +1,3 @@
+ruby_version=$(ruby -e 'puts RUBY_VERSION')
+
+git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/$ruby_version/x64/lib/ruby/site_ruby --unsafe-paths

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -16,7 +16,7 @@ steps:
   displayName: 'work around readline crash (for https://github.com/bundler/bundler/issues/6902)'
 
 - script: |
-    git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/2.4.3/x64/lib/ruby/site_ruby --unsafe-paths
+    git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/2.4.5/x64/lib/ruby/site_ruby --unsafe-paths
   displayName: 'patch local readline implementation (for https://github.com/bundler/bundler/issues/6907)'
 
 - script: |

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -2,7 +2,7 @@ steps:
 
 - task: UseRubyVersion@0
   inputs:
-    versionSpec: '= 2.4'
+    versionSpec: '= 2.4.5'
 
 - script: |
     ruby -v

--- a/.azure-pipelines/steps.yml
+++ b/.azure-pipelines/steps.yml
@@ -2,7 +2,7 @@ steps:
 
 - task: UseRubyVersion@0
   inputs:
-    versionSpec: '= 2.4.5'
+    versionSpec: '= 2.4'
 
 - script: |
     ruby -v
@@ -16,7 +16,7 @@ steps:
   displayName: 'work around readline crash (for https://github.com/bundler/bundler/issues/6902)'
 
 - script: |
-    git apply --ignore-space-change --ignore-whitespace .azure-pipelines\rbreadline.diff --directory=C:/hostedtoolcache/windows/Ruby/2.4.5/x64/lib/ruby/site_ruby --unsafe-paths
+    bash .azure-pipelines\patch_readline.sh
   displayName: 'patch local readline implementation (for https://github.com/bundler/bundler/issues/6907)'
 
 - script: |

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://rubytogether.org

--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --color
 --warnings
 --require spec_helper
+--order random

--- a/Rakefile
+++ b/Rakefile
@@ -97,15 +97,10 @@ namespace :spec do
   end
 
   desc "Run the spec suite with the sudo tests"
-  task :sudo => %w[set_sudo spec clean_sudo]
+  task :sudo => %w[set_sudo spec]
 
   task :set_sudo do
     ENV["BUNDLER_SUDO_TESTS"] = "1"
-  end
-
-  task :clean_sudo do
-    puts "Cleaning up sudo test files..."
-    system "sudo rm -rf #{File.expand_path("../tmp/sudo_gem_home", __FILE__)}"
   end
 
   # RubyGems specs by version
@@ -121,7 +116,7 @@ namespace :spec do
 
       # Create tasks like spec:rubygems:v1.8.3:sudo to run the sudo specs
       namespace rg do
-        task :sudo => ["set_sudo", rg, "clean_sudo"]
+        task :sudo => ["set_sudo", rg]
         task :realworld => ["set_realworld", rg]
       end
 
@@ -139,7 +134,7 @@ namespace :spec do
     end
 
     namespace "co" do
-      task :sudo => ["set_sudo", "co", "clean_sudo"]
+      task :sudo => ["set_sudo", "co"]
       task :realworld => ["set_realworld", "co"]
     end
 

--- a/lib/bundler/feature_flag.rb
+++ b/lib/bundler/feature_flag.rb
@@ -37,7 +37,6 @@ module Bundler
     settings_flag(:deployment_means_frozen) { bundler_3_mode? }
     settings_flag(:disable_multisource) { bundler_3_mode? }
     settings_flag(:forget_cli_options) { bundler_3_mode? }
-    settings_flag(:global_path_appends_ruby_scope) { bundler_3_mode? }
     settings_flag(:global_gem_cache) { bundler_3_mode? }
     settings_flag(:only_update_to_newer_versions) { bundler_3_mode? }
     settings_flag(:path_relative_to_cwd) { bundler_3_mode? }

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -196,6 +196,7 @@ module Bundler
         # add any user agent strings set in the config
         extra_ua = Bundler.settings[:user_agent]
         agent << " " << extra_ua if extra_ua
+        #calling the metrics method in the user agent for now
         metrics
         agent
       end
@@ -309,10 +310,10 @@ module Bundler
     def downloader
       @downloader ||= Downloader.new(connection, self.class.redirect_limit)
     end
-
+    
     def metrics
-      @metrics = Metrics.new
-      @metrics.add_metrics(cis)
+      #send the ci's to metrics otherwise its undefined, the rest can be collected locally
+      @metrics = Metrics.new.add_metrics(cis)
     end
 
   end

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -175,19 +175,6 @@ module Bundler
         agent << " ruby/#{ruby.versions_string(ruby.versions)}"
         agent << " (#{ruby.host})"
         agent << " command/#{ARGV.first}"
-
-         puts "BEFORE SENDING"
-        uri2 = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
-        http2 = Net::HTTP.new(uri2.host, uri2.port)
-        http2.use_ssl = true
-        request2 = Net::HTTP::Post.new(uri2.request_uri)
-        hash = {}
-        hash["ver"] = String.new("bundler/#{Bundler::VERSION}")
-        request2.set_form_data(hash)
-        response2 = http2.request(request2)
-         puts "AFTER SENDING"
-        p response2
-
         if ruby.engine != "ruby"
           # engine_version raises on unknown engines
           engine_version = begin
@@ -208,6 +195,26 @@ module Bundler
         # add any user agent strings set in the config
         extra_ua = Bundler.settings[:user_agent]
         agent << " " << extra_ua if extra_ua
+
+        puts "BEFORE SENDING"
+        uri2 = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
+        http2 = Net::HTTP.new(uri2.host, uri2.port)
+        http2.use_ssl = true
+        request2 = Net::HTTP::Post.new(uri2.request_uri)
+        metrics = {}
+        metrics["Request ID"] = SecureRandom.hex(8)
+        metrics["Bundler Version"] = "bundler/#{Bundler::VERSION}"
+        metrics["Rubygems Version"] = "rubygems/#{Gem::VERSION}"
+        metrics["Ruby Versions"] = "ruby/#{ruby.versions_string(ruby.versions)}"
+        metrics["Roby Host"] = "(#{ruby.host})"
+        metrics["Command"] = "command/#{ARGV.first}"
+        metrics["Ruby Engine"] = "#{ruby.engine}/#{ruby.versions_string(engine_version)}"
+        metrics["Options"] = "options/#{Bundler.settings.all.join(",")}"
+        metrics["ci"] = "ci/#{cis.join(",")}" if cis.any?
+        metrics["Extra UA strings set in config"] = extra_ua if extra_ua
+        request2.set_form_data(metrics)
+        response2 = http2.request(request2)
+        puts "AFTER SENDING"
 
         agent
       end

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -170,12 +170,23 @@ module Bundler
     def user_agent
       @user_agent ||= begin
         ruby = Bundler::RubyVersion.system
-
         agent = String.new("bundler/#{Bundler::VERSION}")
         agent << " rubygems/#{Gem::VERSION}"
         agent << " ruby/#{ruby.versions_string(ruby.versions)}"
         agent << " (#{ruby.host})"
         agent << " command/#{ARGV.first}"
+
+         puts "BEFORE SENDING"
+        uri2 = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
+        http2 = Net::HTTP.new(uri2.host, uri2.port)
+        http2.use_ssl = true
+        request2 = Net::HTTP::Post.new(uri2.request_uri)
+        hash = {}
+        hash["ver"] = String.new("bundler/#{Bundler::VERSION}")
+        request2.set_form_data(hash)
+        response2 = http2.request(request2)
+         puts "AFTER SENDING"
+        p response2
 
         if ruby.engine != "ruby"
           # engine_version raises on unknown engines

--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -171,7 +171,10 @@ module Bundler
     def user_agent
       @user_agent ||= begin
         ruby = Bundler::RubyVersion.system
-        agent = String.new("bundler/#{Bundler::VERSION}")
+        # CONTINUE
+        # metrics
+        # agent = @metrics.metrics_hash["Bundler Version"]
+        agent = "bundler/#{Bundler::VERSION}"
         agent << " rubygems/#{Gem::VERSION}"
         agent << " ruby/#{ruby.versions_string(ruby.versions)}"
         agent << " (#{ruby.host})"
@@ -196,8 +199,7 @@ module Bundler
         # add any user agent strings set in the config
         extra_ua = Bundler.settings[:user_agent]
         agent << " " << extra_ua if extra_ua
-        #calling the metrics method in the user agent for now
-        metrics
+        # calling the metrics method in the user agent for now
         agent
       end
     end
@@ -218,21 +220,6 @@ module Bundler
   private
 
     FETCHERS = [CompactIndex, Dependency, Index].freeze
-
-    def cis
-      env_cis = {
-        "TRAVIS" => "travis",
-        "CIRCLECI" => "circle",
-        "SEMAPHORE" => "semaphore",
-        "JENKINS_URL" => "jenkins",
-        "BUILDBOX" => "buildbox",
-        "GO_SERVER_URL" => "go",
-        "SNAP_CI" => "snap",
-        "CI_NAME" => ENV["CI_NAME"],
-        "CI" => "ci",
-      }
-      env_cis.find_all {|env, _| ENV[env] }.map {|_, ci| ci }
-    end
 
     def connection
       @connection ||= begin
@@ -310,10 +297,10 @@ module Bundler
     def downloader
       @downloader ||= Downloader.new(connection, self.class.redirect_limit)
     end
-    
+
     def metrics
-      #send the ci's to metrics otherwise its undefined, the rest can be collected locally
-      @metrics = Metrics.new.add_metrics(cis)
+      @metrics = Metrics.new
+      @metrics.add_metrics
     end
 
   end

--- a/lib/bundler/fetcher/metrics.rb
+++ b/lib/bundler/fetcher/metrics.rb
@@ -1,0 +1,39 @@
+module Bundler
+  class Fetcher
+    class Metrics
+      def initialize
+        @uri = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
+        @http = Net::HTTP.new(@uri.host, @uri.port)
+        @http.use_ssl = true
+        @request = Net::HTTP::Post.new(@uri.request_uri)
+        @metrics = Hash.new
+      end
+      def add_metrics(cis)
+        puts "SENDING METRICS..."
+        ruby = Bundler::RubyVersion.system
+        @metrics["Request ID"] = SecureRandom.hex(8)
+        @metrics["Bundler Version"] = "bundler/#{Bundler::VERSION}"
+        @metrics["Rubygems Version"] = "rubygems/#{Gem::VERSION}"
+        @metrics["Ruby Versions"] = "ruby/#{ruby.versions_string(ruby.versions)}"
+        @metrics["Roby Host"] = "(#{ruby.host})"
+        @metrics["Command"] = "command/#{ARGV.first}"
+        if ruby.engine != "ruby"
+          # engine_version raises on unknown engines
+          engine_version = begin
+                             ruby.engine_versions
+                           rescue RuntimeError
+                             "???"
+                           end
+          @metrics["Ruby Engine"] = "#{ruby.engine}/#{ruby.versions_string(engine_version)}"
+        end
+        @metrics["Options"] = "options/#{Bundler.settings.all.join(",")}"
+        @metrics["ci"] = "ci/#{cis.join(",")}" if cis.any?
+        extra_ua = Bundler.settings[:user_agent]
+        @metrics["Extra UA strings set in config"] = extra_ua if extra_ua
+        @request.set_form_data(@metrics)
+        @http.request(@request)
+        puts "METRICS SENT"
+      end
+    end
+  end
+end

--- a/lib/bundler/fetcher/metrics.rb
+++ b/lib/bundler/fetcher/metrics.rb
@@ -1,15 +1,19 @@
 module Bundler
   class Fetcher
     class Metrics
+
       def initialize
-        @uri = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
-        @http = Net::HTTP.new(@uri.host, @uri.port)
+        #dummy server for now
+        uri = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
+        @http = Net::HTTP.new(uri.host, uri.port)
         @http.use_ssl = true
-        @request = Net::HTTP::Post.new(@uri.request_uri)
+        @request = Net::HTTP::Post.new(uri.request_uri)
         @metrics = Hash.new
       end
+
+      #sending user agent metrics over http
       def add_metrics(cis)
-        puts "SENDING METRICS..."
+        puts "SENDING METRICS"
         ruby = Bundler::RubyVersion.system
         @metrics["Request ID"] = SecureRandom.hex(8)
         @metrics["Bundler Version"] = "bundler/#{Bundler::VERSION}"

--- a/lib/bundler/fetcher/metrics.rb
+++ b/lib/bundler/fetcher/metrics.rb
@@ -30,9 +30,7 @@ module Bundler
 
       # sending user agent metrics over http
       def add_metrics
-        puts "SENDING METRICS"
         ruby = Bundler::RubyVersion.system
-        @metrics_hash["Request ID"] = SecureRandom.hex(8)
         @metrics_hash["Bundler Version"] = "bundler/#{Bundler::VERSION}"
         @metrics_hash["Rubygems Version"] = "rubygems/#{Gem::VERSION}"
         @metrics_hash["Ruby Versions"] = "ruby/#{ruby.versions_string(ruby.versions)}"
@@ -49,11 +47,16 @@ module Bundler
         end
         @metrics_hash["Options"] = "options/#{Bundler.settings.all.join(",")}"
         @metrics_hash["CI"] = "ci/#{cis.join(",")}" if cis.any?
+        # add a random ID so we can consolidate runs server-side
+        @metrics_hash["Request ID"] = SecureRandom.hex(8)
+        # add any user agent strings set in the config
         extra_ua = Bundler.settings[:user_agent]
         @metrics_hash["Extra UA in config"] = extra_ua if extra_ua
+      end
+
+      def send_metrics
         @request.set_form_data(@metrics_hash)
         @http.request(@request)
-        puts "METRICS SENT"
       end
     end
   end

--- a/lib/bundler/fetcher/metrics.rb
+++ b/lib/bundler/fetcher/metrics.rb
@@ -2,25 +2,42 @@ module Bundler
   class Fetcher
     class Metrics
 
+      attr_accessor :metrics_hash
+
       def initialize
-        #dummy server for now
-        uri = URI.parse("https://webhook.site/6e4832e5-df36-422d-ae2f-53c4e85ab475")
+        # dummy server for now
+        uri = URI.parse("https://webhook.site/ee1e4493-c0f0-4e40-84fb-3a36d79d47fb")
         @http = Net::HTTP.new(uri.host, uri.port)
         @http.use_ssl = true
         @request = Net::HTTP::Post.new(uri.request_uri)
-        @metrics = Hash.new
+        @metrics_hash = Hash.new
       end
 
-      #sending user agent metrics over http
-      def add_metrics(cis)
+      def cis
+        env_cis = {
+          "TRAVIS" => "travis",
+          "CIRCLECI" => "circle",
+          "SEMAPHORE" => "semaphore",
+          "JENKINS_URL" => "jenkins",
+          "BUILDBOX" => "buildbox",
+          "GO_SERVER_URL" => "go",
+          "SNAP_CI" => "snap",
+          "CI_NAME" => ENV["CI_NAME"],
+          "CI" => "ci",
+        }
+        env_cis.find_all {|env, _| ENV[env] }.map {|_, ci| ci }
+      end
+
+      # sending user agent metrics over http
+      def add_metrics
         puts "SENDING METRICS"
         ruby = Bundler::RubyVersion.system
-        @metrics["Request ID"] = SecureRandom.hex(8)
-        @metrics["Bundler Version"] = "bundler/#{Bundler::VERSION}"
-        @metrics["Rubygems Version"] = "rubygems/#{Gem::VERSION}"
-        @metrics["Ruby Versions"] = "ruby/#{ruby.versions_string(ruby.versions)}"
-        @metrics["Roby Host"] = "(#{ruby.host})"
-        @metrics["Command"] = "command/#{ARGV.first}"
+        @metrics_hash["Request ID"] = SecureRandom.hex(8)
+        @metrics_hash["Bundler Version"] = "bundler/#{Bundler::VERSION}"
+        @metrics_hash["Rubygems Version"] = "rubygems/#{Gem::VERSION}"
+        @metrics_hash["Ruby Versions"] = "ruby/#{ruby.versions_string(ruby.versions)}"
+        @metrics_hash["Roby Host"] = "(#{ruby.host})"
+        @metrics_hash["Command"] = "command/#{ARGV.first}"
         if ruby.engine != "ruby"
           # engine_version raises on unknown engines
           engine_version = begin
@@ -28,13 +45,13 @@ module Bundler
                            rescue RuntimeError
                              "???"
                            end
-          @metrics["Ruby Engine"] = "#{ruby.engine}/#{ruby.versions_string(engine_version)}"
+          @metrics_hash["Ruby Engine"] = "#{ruby.engine}/#{ruby.versions_string(engine_version)}"
         end
-        @metrics["Options"] = "options/#{Bundler.settings.all.join(",")}"
-        @metrics["ci"] = "ci/#{cis.join(",")}" if cis.any?
+        @metrics_hash["Options"] = "options/#{Bundler.settings.all.join(",")}"
+        @metrics_hash["CI"] = "ci/#{cis.join(",")}" if cis.any?
         extra_ua = Bundler.settings[:user_agent]
-        @metrics["Extra UA strings set in config"] = extra_ua if extra_ua
-        @request.set_form_data(@metrics)
+        @metrics_hash["Extra UA in config"] = extra_ua if extra_ua
+        @request.set_form_data(@metrics_hash)
         @http.request(@request)
         puts "METRICS SENT"
       end

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -209,17 +209,17 @@ module Bundler
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, true, false, false)
+        return Path.new(path, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)
-      Path.new(self[:path], true, system_path, Bundler.feature_flag.default_install_uses_path?)
+      Path.new(self[:path], system_path, Bundler.feature_flag.default_install_uses_path?)
     end
 
-    Path = Struct.new(:explicit_path, :append_ruby_scope, :system_path, :default_install_uses_path) do
+    Path = Struct.new(:explicit_path, :system_path, :default_install_uses_path) do
       def path
         path = base_path
-        path = File.join(path, Bundler.ruby_scope) if append_ruby_scope && !use_system_gems?
+        path = File.join(path, Bundler.ruby_scope) unless use_system_gems?
         path
       end
 

--- a/lib/bundler/settings.rb
+++ b/lib/bundler/settings.rb
@@ -33,7 +33,6 @@ module Bundler
       frozen
       gem.coc
       gem.mit
-      global_path_appends_ruby_scope
       global_gem_cache
       ignore_messages
       init_gems_rb
@@ -205,13 +204,12 @@ module Bundler
       locations
     end
 
-    # for legacy reasons, in Bundler 1, the ruby scope isnt appended when the setting comes from ENV or the global config,
-    # nor do we respect :disable_shared_gems
+    # for legacy reasons, in Bundler 2, we do not respect :disable_shared_gems
     def path
       key  = key_for(:path)
       path = ENV[key] || @global_config[key]
       if path && !@temporary.key?(key) && !@local_config.key?(key)
-        return Path.new(path, Bundler.feature_flag.global_path_appends_ruby_scope?, false, false)
+        return Path.new(path, true, false, false)
       end
 
       system_path = self["path.system"] || (self[:disable_shared_gems] == false)

--- a/man/bundle-config.ronn
+++ b/man/bundle-config.ronn
@@ -202,9 +202,6 @@ learn more about their operation in [bundle install(1)](bundle-install.1.html).
 * `global_gem_cache` (`BUNDLE_GLOBAL_GEM_CACHE`):
    Whether Bundler should cache all gems globally, rather than locally to the
    installing Ruby installation.
-* `global_path_appends_ruby_scope` (`BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE`):
-   Whether Bundler should append the Ruby scope (e.g. engine and ABI version)
-   to a globally-configured path.
 * `ignore_messages` (`BUNDLE_IGNORE_MESSAGES`): When set, no post install
    messages will be printed. To silence a single gem, use dot notation like
    `ignore_messages.httparty true`.

--- a/spec/bundler/bundler_spec.rb
+++ b/spec/bundler/bundler_spec.rb
@@ -370,54 +370,51 @@ EOF
         it { should be true }
       end
     end
-  end
 
-  describe "#requires_sudo?" do
-    before do
-      allow(Bundler).to receive(:which).with("sudo").and_return("/usr/bin/sudo")
-      FileUtils.mkdir_p("tmp/vendor/bundle")
-      FileUtils.mkdir_p("tmp/vendor/bin_dir")
-    end
-    after do
-      FileUtils.rm_rf("tmp/vendor/bundle")
-      FileUtils.rm_rf("tmp/vendor/bin_dir")
-      Bundler.remove_instance_variable(:@requires_sudo_ran)
-      Bundler.remove_instance_variable(:@requires_sudo)
-    end
-    context "writable paths" do
-      it "should return false and display nothing" do
-        allow(Bundler).to receive(:bundle_path).and_return(Pathname("tmp/vendor/bundle"))
-        expect(Bundler.ui).to_not receive(:warn)
-        expect(Bundler.requires_sudo?).to eq(false)
-      end
-    end
-    context "unwritable paths" do
+    context "path writability" do
       before do
-        FileUtils.touch("tmp/vendor/bundle/unwritable1.txt")
-        FileUtils.touch("tmp/vendor/bundle/unwritable2.txt")
-        FileUtils.touch("tmp/vendor/bin_dir/unwritable3.txt")
-        FileUtils.chmod(0o400, "tmp/vendor/bundle/unwritable1.txt")
-        FileUtils.chmod(0o400, "tmp/vendor/bundle/unwritable2.txt")
-        FileUtils.chmod(0o400, "tmp/vendor/bin_dir/unwritable3.txt")
+        FileUtils.mkdir_p("tmp/vendor/bundle")
+        FileUtils.mkdir_p("tmp/vendor/bin_dir")
       end
-      it "should return true and display warn message" do
-        allow(Bundler).to receive(:bundle_path).and_return(Pathname("tmp/vendor/bundle"))
-        bin_dir = Pathname("tmp/vendor/bin_dir/")
+      after do
+        FileUtils.rm_rf("tmp/vendor/bundle")
+        FileUtils.rm_rf("tmp/vendor/bin_dir")
+      end
+      context "writable paths" do
+        it "should return false and display nothing" do
+          allow(Bundler).to receive(:bundle_path).and_return(Pathname("tmp/vendor/bundle"))
+          expect(Bundler.ui).to_not receive(:warn)
+          expect(Bundler.requires_sudo?).to eq(false)
+        end
+      end
+      context "unwritable paths" do
+        before do
+          FileUtils.touch("tmp/vendor/bundle/unwritable1.txt")
+          FileUtils.touch("tmp/vendor/bundle/unwritable2.txt")
+          FileUtils.touch("tmp/vendor/bin_dir/unwritable3.txt")
+          FileUtils.chmod(0o400, "tmp/vendor/bundle/unwritable1.txt")
+          FileUtils.chmod(0o400, "tmp/vendor/bundle/unwritable2.txt")
+          FileUtils.chmod(0o400, "tmp/vendor/bin_dir/unwritable3.txt")
+        end
+        it "should return true and display warn message" do
+          allow(Bundler).to receive(:bundle_path).and_return(Pathname("tmp/vendor/bundle"))
+          bin_dir = Pathname("tmp/vendor/bin_dir/")
 
-        # allow File#writable? to be called with args other than the stubbed on below
-        allow(File).to receive(:writable?).and_call_original
+          # allow File#writable? to be called with args other than the stubbed on below
+          allow(File).to receive(:writable?).and_call_original
 
-        # fake make the directory unwritable
-        allow(File).to receive(:writable?).with(bin_dir).and_return(false)
-        allow(Bundler).to receive(:system_bindir).and_return(Pathname("tmp/vendor/bin_dir/"))
-        message = <<-MESSAGE.chomp
+          # fake make the directory unwritable
+          allow(File).to receive(:writable?).with(bin_dir).and_return(false)
+          allow(Bundler).to receive(:system_bindir).and_return(Pathname("tmp/vendor/bin_dir/"))
+          message = <<-MESSAGE.chomp
 Following files may not be writable, so sudo is needed:
   tmp/vendor/bin_dir/
   tmp/vendor/bundle/unwritable1.txt
   tmp/vendor/bundle/unwritable2.txt
 MESSAGE
-        expect(Bundler.ui).to receive(:warn).with(message)
-        expect(Bundler.requires_sudo?).to eq(true)
+          expect(Bundler.ui).to receive(:warn).with(message)
+          expect(Bundler.requires_sudo?).to eq(true)
+        end
       end
     end
   end

--- a/spec/bundler/fetcher/compact_index_spec.rb
+++ b/spec/bundler/fetcher/compact_index_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe Bundler::Fetcher::CompactIndex do
   end
 
   describe "#specs_for_names" do
+    let(:thread_list) { Thread.list.select {|thread| thread.status == "run" } }
+    let(:thread_inspection) { thread_list.map {|th| "  * #{th}:\n    #{th.backtrace_locations.join("\n    ")}" }.join("\n") }
+
     it "has only one thread open at the end of the run" do
       compact_index.specs_for_names(["lskdjf"])
 
-      thread_count = Thread.list.count {|thread| thread.status == "run" }
-      expect(thread_count).to eq 1
+      thread_count = thread_list.count
+      expect(thread_count).to eq(1), "Expected 1 active thread after `#specs_for_names`, but found #{thread_count}. In particular, found:\n#{thread_inspection}"
     end
 
     it "calls worker#stop during the run" do

--- a/spec/bundler/fetcher/metrics_spec.rb
+++ b/spec/bundler/fetcher/metrics_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Bundler::Fetcher::Metrics do
+  let(:uri) { URI("https://example.com") }
+  let(:http) { Net::HTTP.new(uri.host, uri.port)}
+  let(:request) { Net::HTTP::Post.new(uri.request_uri)}
+  let(:metrics_hash) { Hash.new}
+
+  subject(:http) { http.use_ssl = true }
+  subject(:metrics) { Bundler::Fetcher::Metrics.new }
+
+  describe "#add_metrics" do
+    before do
+      metrics.add_metrics
+    end
+    it "builds metrics_hash with current ruby version and Bundler settings" do
+      expect(metrics.metrics_hash["Bundler Version"]).to match(%r{bundler/(\d.)})
+      expect(metrics.metrics_hash["Rubygems Version"]).to match(%r{rubygems/(\d.)})
+      expect(metrics.metrics_hash["Ruby Versions"]).to match(%r{ruby/(\d.)})
+      expect(metrics.metrics_hash["Options"]).to match(%r{options/spec_run})
+      expect(metrics.metrics_hash["Command"]).to match(%r{command/(...)})
+    end
+
+    describe "include CI information" do
+      it "from one CI" do
+        with_env_vars("JENKINS_URL" => "foo") do
+          metrics.add_metrics
+          ci_part = metrics.metrics_hash["CI"]
+          expect(ci_part).to match("jenkins")
+        end
+      end
+
+      it "from many CI" do
+        with_env_vars("TRAVIS" => "foo", "CI_NAME" => "my_ci") do
+          metrics.add_metrics
+          ci_part = metrics.metrics_hash["CI"]
+          expect(ci_part).to match("travis")
+          expect(ci_part).to match("my_ci")
+        end
+      end
+    end
+  end
+end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -140,22 +140,5 @@ RSpec.describe Bundler::Fetcher do
       expect(fetcher.user_agent).to match(%r{ruby/(\d.)})
       expect(fetcher.user_agent).to match(%r{options/foo,bar})
     end
-
-    describe "include CI information" do
-      it "from one CI" do
-        with_env_vars("JENKINS_URL" => "foo") do
-          ci_part = fetcher.user_agent.split(" ").find {|x| x.match(%r{\Aci/}) }
-          expect(ci_part).to match("jenkins")
-        end
-      end
-
-      it "from many CI" do
-        with_env_vars("TRAVIS" => "foo", "CI_NAME" => "my_ci") do
-          ci_part = fetcher.user_agent.split(" ").find {|x| x.match(%r{\Aci/}) }
-          expect(ci_part).to match("travis")
-          expect(ci_part).to match("my_ci")
-        end
-      end
-    end
   end
 end

--- a/spec/bundler/fetcher_spec.rb
+++ b/spec/bundler/fetcher_spec.rb
@@ -140,5 +140,22 @@ RSpec.describe Bundler::Fetcher do
       expect(fetcher.user_agent).to match(%r{ruby/(\d.)})
       expect(fetcher.user_agent).to match(%r{options/foo,bar})
     end
+
+    describe "include CI information" do
+      it "from one CI" do
+        with_env_vars("JENKINS_URL" => "foo") do
+          ci_part = fetcher.user_agent.split(" ").find {|x| x.match(%r{\Aci/}) }
+          expect(ci_part).to match("jenkins")
+        end
+      end
+
+      it "from many CI" do
+        with_env_vars("TRAVIS" => "foo", "CI_NAME" => "my_ci") do
+          ci_part = fetcher.user_agent.split(" ").find {|x| x.match(%r{\Aci/}) }
+          expect(ci_part).to match("travis")
+          expect(ci_part).to match("my_ci")
+        end
+      end
+    end
   end
 end

--- a/spec/bundler/plugin/events_spec.rb
+++ b/spec/bundler/plugin/events_spec.rb
@@ -2,10 +2,14 @@
 
 RSpec.describe Bundler::Plugin::Events do
   context "plugin events" do
+    before { Bundler::Plugin::Events.send :reset }
+
     describe "#define" do
       it "raises when redefining a constant" do
+        Bundler::Plugin::Events.send(:define, :TEST_EVENT, "foo")
+
         expect do
-          Bundler::Plugin::Events.send(:define, :GEM_BEFORE_INSTALL_ALL, "another-value")
+          Bundler::Plugin::Events.send(:define, :TEST_EVENT, "bar")
         end.to raise_error(ArgumentError)
       end
 

--- a/spec/bundler/ruby_version_spec.rb
+++ b/spec/bundler/ruby_version_spec.rb
@@ -399,8 +399,14 @@ RSpec.describe "Bundler::RubyVersion and its subclasses" do
 
       let(:bundler_system_ruby_version) { subject }
 
-      before do
-        Bundler::RubyVersion.instance_variable_set("@ruby_version", nil)
+      around do |example|
+        begin
+          old_ruby_version = Bundler::RubyVersion.instance_variable_get("@ruby_version")
+          Bundler::RubyVersion.instance_variable_set("@ruby_version", nil)
+          example.run
+        ensure
+          Bundler::RubyVersion.instance_variable_set("@ruby_version", old_ruby_version)
+        end
       end
 
       it "should return an instance of Bundler::RubyVersion" do

--- a/spec/commands/newgem_spec.rb
+++ b/spec/commands/newgem_spec.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe "bundle gem" do
-  def reset!
-    super
-    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
-  end
-
   def execute_bundle_gem(gem_name, flag = "")
     bundle! "gem #{gem_name} #{flag}"
     # reset gemspec cache for each test because of commit 3d4163a
@@ -22,6 +17,7 @@ RSpec.describe "bundle gem" do
   end
 
   before do
+    global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
     git_config_content = <<-EOF
     [user]
       name = "Bundler User"
@@ -136,7 +132,6 @@ RSpec.describe "bundle gem" do
     context "git config github.user is absent" do
       before do
         sys_exec("git config --unset github.user")
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -209,7 +204,6 @@ RSpec.describe "bundle gem" do
 
   context "gem naming with relative paths" do
     before do
-      reset!
       in_app_root
     end
 
@@ -281,7 +275,6 @@ RSpec.describe "bundle gem" do
       before do
         `git config --unset user.name`
         `git config --unset user.email`
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -322,7 +315,6 @@ RSpec.describe "bundle gem" do
 
     context "--exe parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --exe"
       end
@@ -338,7 +330,6 @@ RSpec.describe "bundle gem" do
 
     context "--bin parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --bin"
       end
@@ -354,7 +345,6 @@ RSpec.describe "bundle gem" do
 
     context "no --test parameter" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -370,7 +360,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=rspec"
       end
@@ -397,7 +386,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name}"
@@ -412,7 +400,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to rspec and --test is set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test rspec"
         bundle "gem #{gem_name} --test=minitest"
@@ -426,7 +413,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -456,7 +442,6 @@ RSpec.describe "bundle gem" do
 
     context "gem.test setting set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "config set gem.test minitest"
         bundle "gem #{gem_name}"
@@ -482,7 +467,6 @@ RSpec.describe "bundle gem" do
 
     context "--test with no arguments" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test"
       end
@@ -499,7 +483,6 @@ RSpec.describe "bundle gem" do
 
     context "--edit option" do
       it "opens the generated gemspec in the user's text editor" do
-        reset!
         in_app_root
         output = bundle "gem #{gem_name} --edit=echo"
         gemspec_path = File.join(Dir.pwd, gem_name, "#{gem_name}.gemspec")
@@ -515,7 +498,6 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__MIT" => "true", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "false"
       end
-      after { reset! }
       it_behaves_like "--mit flag"
       it_behaves_like "--no-mit flag"
     end
@@ -529,7 +511,6 @@ RSpec.describe "bundle gem" do
       before do
         global_config "BUNDLE_GEM__MIT" => "false", "BUNDLE_GEM__TEST" => "false", "BUNDLE_GEM__COC" => "true"
       end
-      after { reset! }
       it_behaves_like "--coc flag"
       it_behaves_like "--no-coc flag"
     end
@@ -572,7 +553,6 @@ RSpec.describe "bundle gem" do
       before do
         `git config --unset user.name`
         `git config --unset user.email`
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -604,7 +584,6 @@ RSpec.describe "bundle gem" do
 
     context "--bin parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --bin"
       end
@@ -620,7 +599,6 @@ RSpec.describe "bundle gem" do
 
     context "no --test parameter" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name}"
       end
@@ -636,7 +614,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to rspec" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=rspec"
       end
@@ -671,7 +648,6 @@ RSpec.describe "bundle gem" do
 
     context "--test parameter set to minitest" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test=minitest"
       end
@@ -713,7 +689,6 @@ RSpec.describe "bundle gem" do
 
     context "--test with no arguments" do
       before do
-        reset!
         in_app_root
         bundle "gem #{gem_name} --test"
       end
@@ -726,7 +701,6 @@ RSpec.describe "bundle gem" do
 
     context "--ext parameter set" do
       before do
-        reset!
         in_app_root
         bundle "gem test_gem --ext"
       end

--- a/spec/install/bundler_spec.rb
+++ b/spec/install/bundler_spec.rb
@@ -140,7 +140,6 @@ RSpec.describe "bundle install" do
 
     it "can install dependencies with newer bundler version with a local path" do
       bundle! "config set path .bundle"
-      bundle! "config set global_path_appends_ruby_scope true"
       install_gemfile! <<-G
         source "file://#{gem_repo2}"
         gem "rails", "3.0"

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -142,6 +142,8 @@ RSpec.describe "when using sudo", :sudo => true do
       bundle :install, :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }
       expect(gem_home.join("bin/rackup")).to exist
       expect(the_bundle).to include_gems "rack 1.0", :env => { "GEM_HOME" => gem_home.to_s, "GEM_PATH" => nil }
+
+      sudo "rm -rf #{tmp("sudo_gem_home")}"
     end
   end
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -52,8 +52,6 @@ RSpec.describe "when using sudo", :sudo => true do
     end
 
     it "installs when BUNDLE_PATH is owned by root" do
-      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
-
       bundle_path = tmp("owned_by_root")
       FileUtils.mkdir_p bundle_path
       sudo "chown -R root #{bundle_path}"
@@ -64,14 +62,12 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join("gems/rack-1.0.0")).to exist
-      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 
     it "installs when BUNDLE_PATH does not exist" do
-      bundle! "config set global_path_appends_ruby_scope false" # consistency in tests between 1.x and 2.x modes
-
       root_path = tmp("owned_by_root")
       FileUtils.mkdir_p root_path
       sudo "chown -R root #{root_path}"
@@ -83,8 +79,8 @@ RSpec.describe "when using sudo", :sudo => true do
         gem "rack", '1.0'
       G
 
-      expect(bundle_path.join("gems/rack-1.0.0")).to exist
-      expect(bundle_path.join("gems/rack-1.0.0").stat.uid).to eq(0)
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0")).to exist
+      expect(bundle_path.join(Bundler.ruby_scope, "gems/rack-1.0.0").stat.uid).to eq(0)
       expect(the_bundle).to include_gems "rack 1.0"
     end
 

--- a/spec/install/gems/sudo_spec.rb
+++ b/spec/install/gems/sudo_spec.rb
@@ -3,11 +3,18 @@
 RSpec.describe "when using sudo", :sudo => true do
   describe "and BUNDLE_PATH is writable" do
     context "but BUNDLE_PATH/build_info is not writable" do
+      let(:subdir) do
+        system_gem_path("cache")
+      end
+
       before do
         bundle! "config set path.system true"
-        subdir = system_gem_path("cache")
         subdir.mkpath
         sudo "chmod u-w #{subdir}"
+      end
+
+      after do
+        sudo "chmod u+w #{subdir}"
       end
 
       it "installs" do
@@ -99,6 +106,10 @@ RSpec.describe "when using sudo", :sudo => true do
   describe "and BUNDLE_PATH is not writable" do
     before do
       sudo "chmod ugo-w #{default_bundle_path}"
+    end
+
+    after do
+      sudo "chmod ugo+w #{default_bundle_path}"
     end
 
     it "installs" do

--- a/spec/install/path_spec.rb
+++ b/spec/install/path_spec.rb
@@ -113,71 +113,36 @@ RSpec.describe "bundle install" do
           expect(the_bundle).to include_gems "rack 1.0.0"
         end
 
-        context "with global_path_appends_ruby_scope set", :bundler => "3" do
-          it "installs gems to ." do
-            set_bundle_path(type, ".")
-            bundle! "config set --global disable_shared_gems true"
+        it "installs gems to ." do
+          set_bundle_path(type, ".")
+          bundle! "config set --global disable_shared_gems true"
 
-            bundle! :install
+          bundle! :install
 
-            paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
-            expect(paths_to_exist).to all exist
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to the path" do
-            set_bundle_path(type, bundled_app("vendor").to_s)
-
-            bundle! :install
-
-            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to the path relative to root when relative" do
-            set_bundle_path(type, "vendor")
-
-            FileUtils.mkdir_p bundled_app("lol")
-            Dir.chdir(bundled_app("lol")) do
-              bundle! :install
-            end
-
-            expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
+          paths_to_exist = %w[cache/rack-1.0.0.gem gems/rack-1.0.0 specifications/rack-1.0.0.gemspec].map {|path| bundled_app(Bundler.ruby_scope, path) }
+          expect(paths_to_exist).to all exist
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
 
-        context "with global_path_appends_ruby_scope unset", :bundler => "< 3" do
-          it "installs gems to ." do
-            set_bundle_path(type, ".")
-            bundle! "config set --global disable_shared_gems true"
+        it "installs gems to the path" do
+          set_bundle_path(type, bundled_app("vendor").to_s)
 
+          bundle! :install
+
+          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+          expect(the_bundle).to include_gems "rack 1.0.0"
+        end
+
+        it "installs gems to the path relative to root when relative" do
+          set_bundle_path(type, "vendor")
+
+          FileUtils.mkdir_p bundled_app("lol")
+          Dir.chdir(bundled_app("lol")) do
             bundle! :install
-
-            expect([bundled_app("cache/rack-1.0.0.gem"), bundled_app("gems/rack-1.0.0"), bundled_app("specifications/rack-1.0.0.gemspec")]).to all exist
-            expect(the_bundle).to include_gems "rack 1.0.0"
           end
 
-          it "installs gems to BUNDLE_PATH with #{type}" do
-            set_bundle_path(type, bundled_app("vendor").to_s)
-
-            bundle :install
-
-            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
-
-          it "installs gems to BUNDLE_PATH relative to root when relative" do
-            set_bundle_path(type, "vendor")
-
-            FileUtils.mkdir_p bundled_app("lol")
-            Dir.chdir(bundled_app("lol")) do
-              bundle :install
-            end
-
-            expect(bundled_app("vendor/gems/rack-1.0.0")).to be_directory
-            expect(the_bundle).to include_gems "rack 1.0.0"
-          end
+          expect(bundled_app("vendor", Bundler.ruby_scope, "gems/rack-1.0.0")).to be_directory
+          expect(the_bundle).to include_gems "rack 1.0.0"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,12 +23,6 @@ end
 $debug = false
 
 Spec::Manpages.setup unless Gem.win_platform?
-Spec::Rubygems.setup
-ENV["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
-ENV["BUNDLE_SPEC_RUN"] = "true"
-
-# Don't wrap output in tests
-ENV["THOR_COLUMNS"] = "10000"
 
 module Gem
   def self.ruby=(ruby)
@@ -104,6 +98,15 @@ RSpec.configure do |config|
   end
 
   config.before :suite do
+    Spec::Rubygems.setup
+    ENV["RUBYOPT"] = original_env["RUBYOPT"] = "#{ENV["RUBYOPT"]} -r#{Spec::Path.spec_dir}/support/hax.rb"
+    ENV["BUNDLE_SPEC_RUN"] = original_env["BUNDLE_SPEC_RUN"] = "true"
+
+    # Don't wrap output in tests
+    ENV["THOR_COLUMNS"] = "10000"
+
+    original_env = ENV.to_hash.delete_if {|k, _v| k.start_with?(Bundler::EnvironmentPreserver::BUNDLER_PREFIX) }
+
     if ENV["BUNDLE_RUBY"]
       FileUtils.cp_r Spec::Path.bindir, File.join(Spec::Path.root, "lib", "exe")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,14 +111,15 @@ RSpec.configure do |config|
     build_repo1
   end
 
-  config.before :each do
+  config.around :each do |example|
+    ENV.replace(original_env)
     reset!
     system_gems []
     in_app_root
     @command_executions = []
-  end
 
-  config.after :each do |example|
+    example.run
+
     all_output = @command_executions.map(&:to_s_verbose).join("\n\n")
     if example.exception && !all_output.empty?
       warn all_output unless config.formatters.grep(RSpec::Core::Formatters::DocumentationFormatter).empty?
@@ -129,7 +130,6 @@ RSpec.configure do |config|
     end
 
     Dir.chdir(original_wd)
-    ENV.replace(original_env)
   end
 
   config.after :suite do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,8 @@ RSpec.configure do |config|
   # forever due to memory constraints
   config.fail_fast ||= 25 if ENV["CI"]
 
+  config.bisect_runner = :shell
+
   if ENV["BUNDLER_SUDO_TESTS"] && Spec::Sudo.present?
     config.filter_run :sudo => true
   else

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,8 +69,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :realworld => true
   end
 
+  git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+
   config.filter_run_excluding :ruby => RequirementChecker.against(RUBY_VERSION)
   config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
+  config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,8 +70,11 @@ RSpec.configure do |config|
     config.filter_run_excluding :realworld => true
   end
 
+  git_version = Bundler::Source::Git::GitProxy.new(nil, nil, nil).version
+
   config.filter_run_excluding :ruby => RequirementChecker.against(RUBY_VERSION)
   config.filter_run_excluding :rubygems => RequirementChecker.against(Gem::VERSION)
+  config.filter_run_excluding :git => RequirementChecker.against(git_version)
   config.filter_run_excluding :rubygems_master => (ENV["RGV"] != "master")
   config.filter_run_excluding :bundler => RequirementChecker.against(Bundler::VERSION.split(".")[0])
   config.filter_run_excluding :ruby_repo => !(ENV["BUNDLE_RUBY"] && ENV["BUNDLE_GEM"]).nil?


### PR DESCRIPTION
### **This concludes my work so far:**
The first four commits have been discussed and reviewed earlier.
(I'll number the commits in ascending order from oldest to newest): 
**_These ones have been previously viewed-_**
---
1. Sending of a single metric over HTTP to a dummy server from within user-agent .
2. Sending of all user-agent metrics over HTTP.
3. Export previous functionality to a different class - metrics.rb.
4. Comments.
---
**_New commits_**
---
5. Sync.
6. Moved cis function to metrics.rb so it could be called internally, removed cis function from fetcher_spec.rb and created the metrics_spec.rb with mostly tests from fetcher_spec.rb.
7. Removed user-agent string generation in fetcher.rb and changed it to have the user_agent method generate it's string from the Metrics::metrics_hash.
Separated metrics collection and sending (no caching for now), metrics are generated when constructing the metrics variable in user_agent method (is this correct?), and are sent in connection method.

*All tests that used to pass before the changes pass now, including metrics_spec tests.
Four tests in fetcher_spec.rb don't pass, if I remeber correctly they didn't pass before as well?
rspec ./spec/bundler/fetcher_spec.rb:20 # Bundler::Fetcher#connection when Gem.configuration doesn't specify http_proxy consider environment vars when determine proxy
rspec ./spec/bundler/fetcher_spec.rb:34 # Bundler::Fetcher#connection when Gem.configuration specifies http_proxy  consider Gem.configuration when determine proxy
rspec ./spec/bundler/fetcher_spec.rb:75 # Bundler::Fetcher#connection when there are proxy environment variable(s) set consider http_proxy
rspec ./spec/bundler/fetcher_spec.rb:80 # Bundler::Fetcher#connection when there are proxy environment variable(s) set consider no_proxy